### PR TITLE
Start Ediens development environment

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -229,7 +229,8 @@ fi
 
 # Generate secure random passwords if they don't exist
 generate_secure_password() {
-    openssl rand -base64 32 | tr -d "=+/" | cut -c1-25
+    # Generate a secure password with only alphanumeric characters
+    openssl rand -hex 32 | tr -d '\n' | cut -c1-25
 }
 
 # Check and create .env file with secure defaults
@@ -240,7 +241,7 @@ if [ ! -f .env ]; then
     
     # Generate secure passwords
     DB_PASSWORD=$(generate_secure_password)
-    JWT_SECRET=$(openssl rand -base64 64)
+    JWT_SECRET=$(openssl rand -hex 64)
     
     # Create .env file with secure defaults
     cat > .env << EOF


### PR DESCRIPTION
Update password and JWT secret generation to use shell-safe characters.

Previously, `openssl rand -base64` could generate characters like `+`, `/`, and `=` which are invalid in shell variable names. This caused `export` commands and `.env` file parsing to fail. Switching to `openssl rand -hex` ensures only alphanumeric characters are used, resolving these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-59fe0e7f-45a1-4396-bc41-61a4a03778e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59fe0e7f-45a1-4396-bc41-61a4a03778e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

