### PR TITLE
Fix tailwind border-border class error

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -21,7 +21,7 @@
 /* Base Styles */
 @layer base {
   * {
-    @apply border-border;
+    @apply border-neutral-200;
   }
   
   body {


### PR DESCRIPTION
Replace invalid `border-border` class with `border-neutral-200` to fix PostCSS compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-53461a46-e4e5-42c8-9b39-0d534d571f78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53461a46-e4e5-42c8-9b39-0d534d571f78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

